### PR TITLE
Migrate to python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copy and paste text across LAN devices.
 
 - You need to install `Flask`:
 
-  - `sudo pip install Flask`
+  - `pip install -u Flask`
 
 - Clone this repository and cd into it:
 
@@ -23,9 +23,9 @@ Copy and paste text across LAN devices.
 
 - To run the copy-paste server:
 
-  - `sudo python copy-paste-server.py`
+  - `python copy-paste-server.py`
 
-- Goto `YourIP:6664` to start using this universal clipboard!
+- Go to `localhost:6664` to start using this universal clipboard!
 
 - You can edit out the script to use any custom port you like.
 
@@ -35,9 +35,9 @@ Copy and paste text across LAN devices.
 
 -  For example:
   
-   - To retrieve text: `sudo python copy-paste-client.py > TextOnServer.txt`
+   - To retrieve text: `python copy-paste-client.py > TextOnServer.txt`
   
-   - To post text: `sudo python copy-paste-client.py 'This text goes on the server'`
+   - To post text: `python copy-paste-client.py 'This text goes on the server'`
 
 ## License:
 

--- a/copy-paste-client.py
+++ b/copy-paste-client.py
@@ -1,9 +1,8 @@
-#!/bin/python
+#!/usr/bin/env python
 
 import requests
 import sys
 from bs4 import BeautifulSoup
-
 
 url = 'http://localhost:6664/'
 headers = {
@@ -20,9 +19,9 @@ headers = {
 }
 
 if len(sys.argv) == 1:
-        page = requests.get(url).text
-        soup = BeautifulSoup(page, 'html.parser')
-        print soup.find('textarea').get_text()
+    page = requests.get(url).text
+    soup = BeautifulSoup(page, 'html.parser')
+    print(soup.find('textarea').get_text())
 else:
-        data = 'text=' + sys.argv[1] +'%21&my-form=Upload+Text'
-        requests.post(url, headers=headers, data=data)
+    data = 'text=' + sys.argv[1] + '%21&my-form=Upload+Text'
+    requests.post(url, headers=headers, data=data)

--- a/copy-paste-server.py
+++ b/copy-paste-server.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 from flask import Flask
 from flask import request
@@ -7,18 +7,21 @@ defaults = ''
 
 app = Flask(__name__)
 
+
 @app.route('/')
 def my_form():
-        template = '<head><meta name="viewport" content="width=device-width"></head><form action="." method="POST"><textarea id="text" name="text" cols="60" rows="10">' + defaults + '</textarea><br><input type="submit" name="my-form" value="Upload Text"></form>'
-	return template
+    template = '<head><meta name="viewport" content="width=device-width"></head><form action="." method="POST"><textarea id="text" name="text" cols="60" rows="10">' + defaults + '</textarea><br><input type="submit" name="my-form" value="Upload Text"></form>'
+    return template
+
 
 @app.route('/', methods=['POST'])
 def my_form_post():
-	global defaults
-        defaults = format(request.form['text'])
-	print defaults
-        template = '<head><meta name="viewport" content="width=device-width"></head><form action="." method="POST"><textarea id="text" name="text" cols="60" rows="10">' + defaults + '</textarea><br><input type="submit" name="my-form" value="Upload Text">Text was uploaded successfully!</form>'
-	return template
+    global defaults
+    defaults = format(request.form['text'])
+    print(defaults)
+    template = '<head><meta name="viewport" content="width=device-width"></head><form action="." method="POST"><textarea id="text" name="text" cols="60" rows="10">' + defaults + '</textarea><br><input type="submit" name="my-form" value="Upload Text">Text was uploaded successfully!</form>'
+    return template
+
 
 if __name__ == '__main__':
-        app.run(threaded=True, debug=True, host='0.0.0.0', port=6664)
+    app.run(threaded=True, debug=True, host='0.0.0.0', port=6664)


### PR DESCRIPTION
The major change is to move the code to python 3 and use `env` in the `hashbang` to make the choice of python executable portable. The other change is to run it through `yapf` for formatting the code properly. There was a problem of mixing tabs and spaces.